### PR TITLE
chore: v1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.6.1 (Jan 9, 2020)
+
+ * chore: Switched to new `appcd.apiVersion`.
+   [(DAEMON-309)](https://jira.appcelerator.org/browse/DAEMON-309)
+ * chore: Updated dependencies.
+
 # v1.6.0 (Nov 8, 2019)
 
  * feat: Wired up live configuration changes.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2017-2019 by Axway, Inc.
+Copyright 2017-2020 by Axway, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appcd/plugin-jdk",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "JDK service for the Appc Daemon",
   "main": "./dist/index",
   "author": "Appcelerator, Inc. <npmjs@appcelerator.com>",
@@ -16,19 +16,19 @@
     "test": "gulp test"
   },
   "dependencies": {
-    "gawk": "^4.6.6",
-    "jdklib": "^3.0.1",
-    "semver": "^6.3.0",
+    "gawk": "^4.7.0",
+    "jdklib": "^3.0.2",
+    "semver": "^7.1.1",
     "source-map-support": "^0.5.16"
   },
   "devDependencies": {
-    "appcd-gulp": "^2.3.0"
+    "appcd-gulp": "^2.3.1"
   },
   "homepage": "https://github.com/appcelerator/appc-daemon",
   "bugs": "https://github.com/appcelerator/appcd-plugin-jdk/issues",
   "repository": "https://github.com/appcelerator/appcd-plugin-jdk",
   "appcd": {
-    "appcdVersion": "1.x || 2.x || 3.x",
+    "apiVersion": "1.x",
     "config": "./conf/config.js",
     "name": "jdk",
     "type": "external"


### PR DESCRIPTION
chore: Switched to new 'appcd.apiVersion'.
chore: Updated npm deps.