### PR TITLE
v1.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v1.6.2 (Jun 5, 2020)
+
+ * chore: Added API version 2.x.
+ * chore: Transpile for Node 10 instead of Node 8. Not a breaking change as appcd has always
+   guaranteed Node 10 or newer.
+ * chore: Updated dependencies.
+
 # v1.6.1 (Jan 9, 2020)
 
  * chore: Switched to new `appcd.apiVersion`.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,5 +4,5 @@ require('appcd-gulp')({
 	exports,
 	pkgJson:  require('./package.json'),
 	template: 'standard',
-	babel:    'node8'
+	babel:    'node10'
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appcd/plugin-jdk",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "JDK service for the Appc Daemon",
   "main": "./dist/index",
   "author": "Appcelerator, Inc. <npmjs@appcelerator.com>",
@@ -16,19 +16,19 @@
     "test": "gulp test"
   },
   "dependencies": {
-    "gawk": "^4.7.0",
+    "gawk": "^4.7.1",
     "jdklib": "^3.0.2",
-    "semver": "^7.1.1",
-    "source-map-support": "^0.5.16"
+    "semver": "^7.3.2",
+    "source-map-support": "^0.5.19"
   },
   "devDependencies": {
-    "appcd-gulp": "^2.3.1"
+    "appcd-gulp": "^3.0.0"
   },
   "homepage": "https://github.com/appcelerator/appc-daemon",
   "bugs": "https://github.com/appcelerator/appcd-plugin-jdk/issues",
   "repository": "https://github.com/appcelerator/appcd-plugin-jdk",
   "appcd": {
-    "apiVersion": "1.x",
+    "apiVersion": "1.x || 2.x",
     "config": "./conf/config.js",
     "name": "jdk",
     "type": "external"


### PR DESCRIPTION
chore: Added API version 2.x.
chore: Transpile for Node 10 instead of Node 8.
chore: Updated dependencies.